### PR TITLE
t in load-theme

### DIFF
--- a/heaven-and-hell.el
+++ b/heaven-and-hell.el
@@ -61,7 +61,7 @@ Themes will be loaded if they weren't loaded previously."
     (let ((themes (if (listp theme-or-themes) theme-or-themes `(,theme-or-themes))))
       (dolist (theme themes)
 	(unless (custom-theme-p theme)
-	  (load-theme theme)))
+	  (load-theme theme t)))
       (custom-set-variables `(custom-enabled-themes (quote ,themes))))))
 
 ;;;###autoload


### PR DESCRIPTION
For non-preinstalled themes, load-theme without `t` will ask if the theme is safe to load. Adding `t` eliminates that prompt.